### PR TITLE
Add bind method to Schmervice class

### DIFF
--- a/API.md
+++ b/API.md
@@ -33,6 +33,9 @@ The hapi plugin `options` passed to the constructor.
 ### `service.context`
 The context of `service.server` set using [`server.bind()`](https://github.com/hapijs/hapi/blob/master/API.md#server.bind()).  Will be `null` if no context has been set.  This is implemented lazily as a getter based upon `service.server` so that services can be part of the context without introducing any circular dependencies between the two.
 
+### `service.bind()`
+Returns a new service instance where all methods are bound to the service instance allowing you to deconstruct methods without losing the `this` context.
+
 ### `async service.initialize()`
 This is not implemented on the base service class, but when it is implemented by an extending class then it will be called during `server` initialization (via `onPreStart` [server extension](https://github.com/hapijs/hapi/blob/master/API.md#server.ext()) added when the service is instanced).
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,38 @@ exports.Service = class Service {
             this[methodName] = this.server.methods.schmervice[instanceName][methodName];
         });
     }
+
+    bind() {
+
+        if (!this._boundInstance) {
+
+            const boundInstance = Object.create(this);
+
+            let chain = boundInstance;
+
+            while (chain !== Object.prototype) {
+
+                for (const key of Reflect.ownKeys(chain)) {
+
+                    if (key === 'constructor') {
+                        continue;
+                    }
+
+                    const descriptor = Reflect.getOwnPropertyDescriptor(chain, key);
+
+                    if (typeof descriptor.value === 'function') {
+                        boundInstance[key] = boundInstance[key].bind(this);
+                    }
+                }
+
+                chain = Reflect.getPrototypeOf(chain);
+            }
+
+            this._boundInstance = boundInstance;
+        }
+
+        return this._boundInstance;
+    }
 };
 
 exports.plugin = {


### PR DESCRIPTION
This pull request addresses a feature request in issue #1. I've added a new `.bind()` to the Schmervice base class that will return an instance with bound context. This will enable deconstructing methods from your service while preserving the `this` context.