### PR TITLE
Register service as object, function factory, or hapi plugin server

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2018 Devin Ivy
+Copyright (c) 2017-2019 Devin Ivy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/lib/index.js
+++ b/lib/index.js
@@ -198,7 +198,7 @@ internals.serviceFactory = (factory, server, options) => {
 internals.instanceName = (name) => {
 
     return name
-        .replace(/[-_]+(.)?/g, (ignore, m) => (m || '').toUpperCase())
+        .replace(/[-_ ]+(.?)/g, (ignore, m) => m.toUpperCase())
         .replace(/^./, (m) => m.toLowerCase());
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,6 +107,8 @@ exports.plugin = {
     }
 };
 
+exports.name = Symbol('serviceName');
+
 internals.boundInstance = Symbol('boundInstance');
 
 internals.services = (getRealm) => {
@@ -125,21 +127,17 @@ internals.registerService = function (services) {
 
     services = [].concat(services);
 
-    services.forEach((Service) => {
+    services.forEach((factory) => {
 
-        Hoek.assert(Service.name, 'The service class must have a name.');
-
+        const { name, instanceName, service } = internals.serviceFactory(factory, this, this.realm.pluginOptions);
         const rootState = internals.rootState(this.realm);
-        const instanceName = internals.instanceName(Service.name);
 
-        Hoek.assert(!rootState[instanceName], `A service named ${Service.name} has already been registered.`);
-
-        const serviceInstance = new Service(this, this.realm.pluginOptions);
+        Hoek.assert(!rootState[instanceName], `A service named ${name} has already been registered.`);
 
         internals.forEachAncestorRealm(this.realm, (realm) => {
 
             const state = internals.state(realm);
-            state[instanceName] = serviceInstance;
+            state[instanceName] = service;
         });
     });
 };
@@ -168,7 +166,40 @@ internals.state = (realm) => {
     return state;
 };
 
-internals.instanceName = (className) => {
+internals.serviceFactory = (factory, server, options) => {
 
-    return className[0].toLowerCase() + className.slice(1);
+    Hoek.assert(factory && (typeof factory === 'object' || typeof factory === 'function'));
+
+    if (typeof factory === 'function' && internals.isClass(factory)) {
+
+        const name = factory[exports.name] || factory.name;
+        Hoek.assert(factory.name, 'The service class must have a name.');
+
+        return {
+            name,
+            instanceName: factory[exports.name] ? name : internals.instanceName(name),
+            service: new factory(server, options)
+        };
+    }
+
+    const service = (typeof factory === 'function') ? factory(server, options) : factory;
+    Hoek.assert(service && typeof service === 'object');
+
+    const name = service[exports.name] || service.name || Hoek.reach(service, ['realm', 'plugin']);
+    Hoek.assert(name, 'The service must have a name.');
+
+    return {
+        name,
+        instanceName: factory[exports.name] ? name : internals.instanceName(name),
+        service
+    };
 };
+
+internals.instanceName = (name) => {
+
+    return name
+        .replace(/[-_]+(.)?/g, (ignore, m) => (m || '').toUpperCase())
+        .replace(/^./, (m) => m.toLowerCase());
+};
+
+internals.isClass = (func) => (/^\s*class\s/).test(func.toString());

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,33 @@ exports.plugin = {
 
 exports.name = Symbol('serviceName');
 
+exports.withName = (name, factory) => {
+
+    if (typeof factory === 'function' && !internals.isClass(factory)) {
+        return (...args) => {
+
+            const service = factory(...args);
+
+            if (typeof service.then === 'function') {
+                return service.then((x) => internals.withNameObject(name, x));
+            }
+
+            return internals.withNameObject(name, service);
+        };
+    }
+
+    return internals.withNameObject(name, factory);
+};
+
+internals.withNameObject = (name, obj) => {
+
+    Hoek.assert(!obj[exports.name], 'Cannot apply a name to a service that already has one.');
+
+    obj[exports.name] = name;
+
+    return obj;
+};
+
 internals.boundInstance = Symbol('boundInstance');
 
 internals.services = (getRealm) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,7 +173,7 @@ internals.serviceFactory = (factory, server, options) => {
     if (typeof factory === 'function' && internals.isClass(factory)) {
 
         const name = factory[exports.name] || factory.name;
-        Hoek.assert(factory.name, 'The service class must have a name.');
+        Hoek.assert(name && typeof factory.name === 'string', 'The service class must have a name.');
 
         return {
             name,
@@ -186,11 +186,11 @@ internals.serviceFactory = (factory, server, options) => {
     Hoek.assert(service && typeof service === 'object');
 
     const name = service[exports.name] || service.name || Hoek.reach(service, ['realm', 'plugin']);
-    Hoek.assert(name, 'The service must have a name.');
+    Hoek.assert(name && typeof name === 'string', 'The service must have a name.');
 
     return {
         name,
-        instanceName: factory[exports.name] ? name : internals.instanceName(name),
+        instanceName: service[exports.name] ? name : internals.instanceName(name),
         service
     };
 };

--- a/test/index.js
+++ b/test/index.js
@@ -166,7 +166,7 @@ describe('Schmervice', () => {
                 }
             });
 
-            it('bind functions up the prototype chain (#Service.caching)', async () => {
+            it('binds functions up the prototype chain (#Service.caching)', async () => {
 
                 const ServiceX = class ServiceX extends Schmervice.Service {
 

--- a/test/index.js
+++ b/test/index.js
@@ -726,6 +726,7 @@ describe('Schmervice', () => {
                 });
 
                 // Class
+
                 const Service = class Service {};
 
                 expect(Schmervice.withName('someServiceClass', Service)).to.shallow.equal(Service);
@@ -733,12 +734,11 @@ describe('Schmervice', () => {
 
                 // Sync factory
 
-                const factory = (...args) => ({ name: 'Unused', some: 'prop', args });
+                const factory = (...args) => ({ name: 'Unused', args });
 
                 expect(Schmervice.withName('someServiceFunction', factory)(1, 2, 3)).to.equal({
                     [Schmervice.name]: 'someServiceFunction',
                     name: 'Unused',
-                    some: 'prop',
                     args: [1, 2, 3]
                 });
 
@@ -748,13 +748,12 @@ describe('Schmervice', () => {
 
                     await new Promise((resolve) => setTimeout(resolve, 1));
 
-                    return { name: 'Unused', some: 'prop', args };
+                    return { name: 'Unused', args };
                 };
 
                 expect(await Schmervice.withName('someServiceAsyncFunction', asyncFactory)(1, 2, 3)).to.equal({
                     [Schmervice.name]: 'someServiceAsyncFunction',
                     name: 'Unused',
-                    some: 'prop',
                     args: [1, 2, 3]
                 });
             });


### PR DESCRIPTION
In the past only classes have been able to be registered as services.  We are moving to also support plain objects and function factories returning plain objects.  This also adds support for naming service instances without camelizing their names by using the new `Schmervice.name` symbol on any class or object.  The `Schmervice.withName()` helper may be used to apply a service name through any service factory.  Finally, this also adds support for registering hapi plugin-servers as services, taking their plugin name as the service name.

Still incoming is documentation.  Once that is in place this PR will no longer be a draft.