### PR TITLE
Namespaces and sandboxing

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ Schmervice may be registered multiple times– it should be registered in any pl
 
 Registers a service with `server` (which may be a plugin's server or root server).  The passed `serviceFactory` used to define the service object may be any of the following:
 
- - A service class.  Services are instanced immediately when they are registered, with `server` and corresponding plugin `options` passed to the constructor.  The service class should be named via its natural class `name` or the [`Schmervice.name`](#schmervicename) symbol (see more under [service naming](#service-naming)).
+ - A service class.  Services are instanced immediately when they are registered, with `server` and corresponding plugin `options` passed to the constructor.  The service class should be named via its natural class `name` or the [`Schmervice.name`](#schmervicename) symbol (see more under [service naming](#service-naming-and-sandboxing)).
 
     ```js
     server.registerService(
@@ -19,7 +19,7 @@ Registers a service with `server` (which may be a plugin's server or root server
     );
     ```
 
- - A factory function returning a service object.  The factory function is called immediately to create the service, with `server` and corresponding plugin `options` passed as arguments.  The service object should be named using either a `name` property or the [`Schmervice.name`](#schmervicename) symbol (see more under [service naming](#service-naming)).
+ - A factory function returning a service object.  The factory function is called immediately to create the service, with `server` and corresponding plugin `options` passed as arguments.  The service object should be named using either a `name` property or the [`Schmervice.name`](#schmervicename) symbol (see more under [service naming](#service-naming-and-sandboxing)).
 
     ```js
     server.registerService((server, options) => ({
@@ -28,7 +28,7 @@ Registers a service with `server` (which may be a plugin's server or root server
     }));
     ```
 
- - A service object.  The service object should be named using either a `name` property or the [`Schmervice.name`](#schmervicename) symbol (see more under [service naming](#service-naming)).
+ - A service object.  The service object should be named using either a `name` property or the [`Schmervice.name`](#schmervicename) symbol (see more under [service naming](#service-naming-and-sandboxing)).
 
     ```js
     server.registerService({
@@ -53,9 +53,9 @@ Registers a service with `server` (which may be a plugin's server or root server
     ```
 
 #### `server.services([namespace])`
-Returns an object containing each service instance keyed by their [instance names](#service-naming).
+Returns an object containing each service instance keyed by their [instance names](#service-naming-and-sandboxing).
 
-The services that are available on this object are only those registered by `server` or any plugins for which `server` is an ancestor (e.g. if `server` has registered a plugin that registers services) that are also not [sandboxed](#TODO).  By passing a `namespace` you can obtain the services from the perspective of a different plugin.  When `namespace` is a string, you receive services that are visibile within the plugin named `namespace`.  And when `namespace` is `true`, you receive services that are visibile to the root server: every service registered with the hapi server– across all plugins– that isn't sandboxed.
+The services that are available on this object are only those registered by `server` or any plugins for which `server` is an ancestor (e.g. if `server` has registered a plugin that registers services) that are also not [sandboxed](#service-naming-and-sandboxing).  By passing a `namespace` you can obtain the services from the perspective of a different plugin.  When `namespace` is a string, you receive services that are visibile within the plugin named `namespace`.  And when `namespace` is `true`, you receive services that are visibile to the root server: every service registered with the hapi server– across all plugins– that isn't sandboxed.
 
 ### Request decorations
 #### `request.services([namespace])`

--- a/API.md
+++ b/API.md
@@ -52,22 +52,26 @@ Registers a service with `server` (which may be a plugin's server or root server
     ]);
     ```
 
-#### `server.services([all])`
-Returns an object containing each service instance keyed by their [instance names](#service-naming).  The services that are available on this object are only those registered by `server` or any plugins for which `server` is an ancestor (e.g. if `server` has registered a plugin that registers services).  When `all` is passed as `true` then every service registered with the hapi server– across all plugins– will be returned.
+#### `server.services([namespace])`
+Returns an object containing each service instance keyed by their [instance names](#service-naming).
+
+The services that are available on this object are only those registered by `server` or any plugins for which `server` is an ancestor (e.g. if `server` has registered a plugin that registers services) that are also not [sandboxed](#TODO).  By passing a `namespace` you can obtain the services from the perspective of a different plugin.  When `namespace` is a string, you receive services that are visibile within the plugin named `namespace`.  And when `namespace` is `true`, you receive services that are visibile to the root server: every service registered with the hapi server– across all plugins– that isn't sandboxed.
 
 ### Request decorations
-#### `request.services([all])`
-See [`server.services()`](#serverservicesall), where `server` is the one in which the `request`'s route was declared (i.e. based upon `request.route.realm`).
+#### `request.services([namespace])`
+See [`server.services()`](#serverservicesnamespace), where `server` is the one in which the `request`'s route was declared (i.e. based upon `request.route.realm`).
 
 ### Response toolkit decorations
-#### `h.services([all])`
-See [`server.services()`](#serverservicesall), where `server` is the one in which the corresponding route or server extension was declared (i.e. based upon `h.realm`).
+#### `h.services([namespace])`
+See [`server.services()`](#serverservicesnamespace), where `server` is the one in which the corresponding route or server extension was declared (i.e. based upon `h.realm`).
 
-## Service naming
+## Service naming and sandboxing
 
-The name of a service is primarily used to determine the key on the result of [`server.services()`](#serverservicesall) where the service may be accessed.  In the case of service classes, the name is derived from the class's natural `name` (e.g. `class ThisIsTheClassName {}`) by default.  In the case of service objects, including those returned from a function, the name is derived from the object's `name` property by default.  In both cases the name is converted to camel-case.
+The name of a service is primarily used to determine the key on the result of [`server.services()`](#serverservicesnamespace) where the service may be accessed.  In the case of service classes, the name is derived from the class's natural `name` (e.g. `class ThisIsTheClassName {}`) by default.  In the case of service objects, including those returned from a function, the name is derived from the object's `name` property by default.  In both cases the name is converted to camel-case.
 
-Sometimes you don't want the name to be based on these properties or you don't want their values camel-cased, which is where [`Schmervice.name`](#schmervicename) and [`Schmervice.withName()`](#schmervicewithnamename-servicefactory) can be useful.
+Sometimes you don't want the name to be based on these properties or you don't want their values camel-cased, which is where [`Schmervice.name`](#schmervicename) and [`Schmervice.withName()`](#schmervicewithnamename-options-servicefactory) can be useful.
+
+Sandboxing is a concept that determines whether a given service is available in the "plugin namespace" accessed using [`server.services()`](#serverservicesnamespace).  By default when you register a service, it is available in the current plugin, and all of that plugin's ancestors up to and including the root server.  A sandboxed service, on the other hand, is only available in the plugin/namespace in which it is registered, which is where [`Schmervice.sandbox`](#schmervicesandbox) and [`Schmervice.withName()`](#schmervicewithnamename-options-servicefactory)'s options come into play.
 
 ### `Schmervice.name`
 
@@ -83,9 +87,32 @@ server.registerService({
 const { myServiceName } = server.services();
 ```
 
-### `Schmervice.withName(name, serviceFactory)`
+### `Schmervice.sandbox`
+
+This is a symbol that can be added as a property to either a service class or service object.  When the value of this property is `true` or `'plugin'`, then the service is not available to [`server.services()`](#serverservicesnamespace) for any namespace aside from that of the plugin that registered the service.  This effectively makes the service "private" within the plugin that it is registered.
+
+The default behavior, which can also be declared explicitly by setting this property to `false` or `'server'`, makes the service available within the current plugin's namespace, and all of the namespaces of that plugin's ancestors up to and including the root server (i.e. the namespace accessed by `server.services(true)`).
+
+```js
+server.registerService({
+    [Schmervice.name]: 'privateService',
+    [Schmervice.sandbox]: true,
+    someMethod: () => {}
+});
+
+// ...
+// Can access the service in the same plugin that registered it
+const { privateService } = server.services();
+
+// But cannot access it in other namespaces, e.g. the root namespace, because it is sandboxed
+const { privateService: doesNotExist } = server.services(true);
+```
+
+### `Schmervice.withName(name, [options], serviceFactory)`
 
 This is a helper that assigns `name` to the service instance or object produced by `serviceFactory` by setting the service's [`Schmervice.name`](#schmervicename).  When `serviceFactory` is a service class or object, `Schmervice.withName()` returns the same service class or object mutated with `Schmervice.name` set accordingly.  When `serviceFactory` is a function, this helper returns a new function that behaves identically but adds the `Schmervice.name` property to its result.  If the resulting service class or object already has a `Schmervice.name` then this helper will fail.
+
+Following a similar logic and behavior to the above: when `options` is present, this helper also assigns `options.sandbox` to the service instance or object produced by `serviceFactory` by setting the service's [`Schmervice.sandbox`](#schmervicesandbox).  If the resulting service class or object already has a `Schmervice.sandbox` then this helper will fail.
 
 ```js
 server.registerService(
@@ -109,6 +136,23 @@ server.registerService(Schmervice.withName('emailService', transport));
 
 // ...
 const { emailService } = server.services();
+```
+
+An example usage of `options.sandbox`:
+
+```js
+server.registerService(
+    Schmervice.withName('privateService', { sandbox: true }, {
+        someMethod: () => {}
+    })
+);
+
+// ...
+// Can access the service in the same plugin that registered it
+const { privateService } = server.services();
+
+// But cannot access it in other namespaces, e.g. the root namespace, because it is sandboxed
+const { privateService: doesNotExist } = server.services(true);
 ```
 
 ## `Schmervice.Service`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2019 Devin Ivy
+Copyright (c) 2017-2020 Devin Ivy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,9 +144,19 @@ internals.services = (getRealm) => {
 
         const realm = getRealm(this);
 
-        return all ?
-            internals.rootState(realm) :
-            internals.state(realm);
+        if (!all) {
+            return internals.state(realm).services;
+        }
+
+        if (typeof all === 'string') {
+            const namespace = internals.rootState(realm).namespaces[all];
+            Hoek.assert(namespace.size !== 0, `The namespace "${namespace}" does not exist.`);
+            Hoek.assert(namespace.size <= 1, `The namespace "${namespace}" is not unique.`);
+            const [namespaceRealm] = [...namespace.values()];
+            return internals.rootState(namespaceRealm).services;
+        }
+
+        return internals.rootState(realm).services;
     };
 };
 
@@ -159,12 +169,15 @@ internals.registerService = function (services) {
         const { name, instanceName, service } = internals.serviceFactory(factory, this, this.realm.pluginOptions);
         const rootState = internals.rootState(this.realm);
 
-        Hoek.assert(!rootState[instanceName], `A service named ${name} has already been registered.`);
+        Hoek.assert(!rootState.services[instanceName], `A service named ${name} has already been registered.`);
+
+        rootState.namespaces[this.realm.plugin] = rootState.namespaces[this.realm.plugin] || new Set();
+        rootState.namespaces[this.realm.plugin].add(this.realm);
 
         internals.forEachAncestorRealm(this.realm, (realm) => {
 
             const state = internals.state(realm);
-            state[instanceName] = service;
+            state.services[instanceName] = service;
         });
     });
 };
@@ -189,7 +202,11 @@ internals.rootState = (realm) => {
 
 internals.state = (realm) => {
 
-    const state = realm.plugins.schmervice = realm.plugins.schmervice || {};
+    const state = realm.plugins.schmervice = realm.plugins.schmervice || {
+        services: {},
+        namespaces: {}
+    };
+
     return state;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,20 +152,20 @@ internals.boundInstance = Symbol('boundInstance');
 
 internals.services = (getRealm) => {
 
-    return function (all) {
+    return function (namespace) {
 
         const realm = getRealm(this);
 
-        if (!all) {
+        if (!namespace) {
             return internals.state(realm).services;
         }
 
-        if (typeof all === 'string') {
-            const namespace = internals.rootState(realm).namespaces[all];
-            Hoek.assert(namespace.size !== 0, `The plugin namespace ${namespace} does not exist.`);
-            Hoek.assert(namespace.size <= 1, `The plugin namespace ${namespace} is not unique.`);
-            const [namespaceRealm] = [...namespace.values()];
-            return internals.rootState(namespaceRealm).services;
+        if (typeof namespace === 'string') {
+            const namespaceSet = internals.rootState(realm).namespaces[namespace];
+            Hoek.assert(namespaceSet, `The plugin namespace ${namespace} does not exist.`);
+            Hoek.assert(namespaceSet.size === 1, `The plugin namespace ${namespace} is not unique: is that plugin registered multiple times?`);
+            const [namespaceRealm] = [...namespaceSet.values()];
+            return internals.state(namespaceRealm).services;
         }
 
         return internals.rootState(realm).services;

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,14 @@ exports.plugin = {
 
 exports.name = Symbol('serviceName');
 
-exports.withName = (name, factory) => {
+exports.sandbox = Symbol('serviceSandbox');
+
+exports.withName = (name, options, factory) => {
+
+    if (typeof factory === 'undefined') {
+        factory = options;
+        options = { sandbox: false };
+    }
 
     if (typeof factory === 'function' && !internals.isClass(factory)) {
         return (...args) => {
@@ -117,21 +124,26 @@ exports.withName = (name, factory) => {
             const service = factory(...args);
 
             if (typeof service.then === 'function') {
-                return service.then((x) => internals.withNameObject(name, x));
+                return service.then((x) => internals.withNameObject(name, options, x));
             }
 
-            return internals.withNameObject(name, service);
+            return internals.withNameObject(name, options, service);
         };
     }
 
-    return internals.withNameObject(name, factory);
+    return internals.withNameObject(name, options, factory);
 };
 
-internals.withNameObject = (name, obj) => {
+internals.withNameObject = (name, { sandbox }, obj) => {
 
     Hoek.assert(!obj[exports.name], 'Cannot apply a name to a service that already has one.');
 
     obj[exports.name] = name;
+
+    if (sandbox) {
+        Hoek.assert(!obj[exports.sandbox], 'Cannot apply a sandbox setting to a service that already has one.');
+        obj[exports.sandbox] = sandbox;
+    }
 
     return obj;
 };
@@ -150,8 +162,8 @@ internals.services = (getRealm) => {
 
         if (typeof all === 'string') {
             const namespace = internals.rootState(realm).namespaces[all];
-            Hoek.assert(namespace.size !== 0, `The namespace "${namespace}" does not exist.`);
-            Hoek.assert(namespace.size <= 1, `The namespace "${namespace}" is not unique.`);
+            Hoek.assert(namespace.size !== 0, `The namespace ${namespace} does not exist.`);
+            Hoek.assert(namespace.size <= 1, `The namespace ${namespace} is not unique.`);
             const [namespaceRealm] = [...namespace.values()];
             return internals.rootState(namespaceRealm).services;
         }
@@ -166,20 +178,32 @@ internals.registerService = function (services) {
 
     services.forEach((factory) => {
 
-        const { name, instanceName, service } = internals.serviceFactory(factory, this, this.realm.pluginOptions);
+        const { name, instanceName, service, sandbox } = internals.serviceFactory(factory, this, this.realm.pluginOptions);
         const rootState = internals.rootState(this.realm);
 
-        Hoek.assert(!rootState.services[instanceName], `A service named ${name} has already been registered.`);
+        Hoek.assert(sandbox || !rootState.services[instanceName], `A service named ${name} has already been registered.`);
 
         rootState.namespaces[this.realm.plugin] = rootState.namespaces[this.realm.plugin] || new Set();
         rootState.namespaces[this.realm.plugin].add(this.realm);
 
+        if (sandbox) {
+            return internals.addServiceToRealm(this.realm, service, instanceName);
+        }
+
         internals.forEachAncestorRealm(this.realm, (realm) => {
 
-            const state = internals.state(realm);
-            state.services[instanceName] = service;
+            internals.addServiceToRealm(realm, service, instanceName);
         });
     });
+};
+
+internals.addServiceToRealm = (realm, service, name) => {
+
+    const state = internals.state(realm);
+
+    Hoek.assert(!state.services[name], `A service named ${name} has already been registered in plugin namespace ${realm.plugin}.`);
+
+    state.services[name] = service;
 };
 
 internals.forEachAncestorRealm = (realm, fn) => {
@@ -222,6 +246,7 @@ internals.serviceFactory = (factory, server, options) => {
         return {
             name,
             instanceName: factory[exports.name] ? name : internals.instanceName(name),
+            sandbox: internals.sandbox(factory[exports.sandbox]),
             service: new factory(server, options)
         };
     }
@@ -235,6 +260,7 @@ internals.serviceFactory = (factory, server, options) => {
     return {
         name,
         instanceName: service[exports.name] ? name : internals.instanceName(name),
+        sandbox: internals.sandbox(service[exports.sandbox]),
         service
     };
 };
@@ -244,6 +270,19 @@ internals.instanceName = (name) => {
     return name
         .replace(/[-_ ]+(.?)/g, (ignore, m) => m.toUpperCase())
         .replace(/^./, (m) => m.toLowerCase());
+};
+
+internals.sandbox = (value) => {
+
+    if (value === 'plugin') {
+        return true;
+    }
+
+    if (value === 'server') {
+        return false;
+    }
+
+    return value;
 };
 
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ internals.services = (getRealm) => {
             const namespaceSet = internals.rootState(realm).namespaces[namespace];
             Hoek.assert(namespaceSet, `The plugin namespace ${namespace} does not exist.`);
             Hoek.assert(namespaceSet.size === 1, `The plugin namespace ${namespace} is not unique: is that plugin registered multiple times?`);
-            const [namespaceRealm] = [...namespaceSet.values()];
+            const [namespaceRealm] = [...namespaceSet];
             return internals.state(namespaceRealm).services;
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ exports.withName = (name, options, factory) => {
 
     if (typeof factory === 'undefined') {
         factory = options;
-        options = { sandbox: false };
+        options = {};
     }
 
     if (typeof factory === 'function' && !internals.isClass(factory)) {
@@ -140,8 +140,8 @@ internals.withNameObject = (name, { sandbox }, obj) => {
 
     obj[exports.name] = name;
 
-    if (sandbox) {
-        Hoek.assert(!obj[exports.sandbox], 'Cannot apply a sandbox setting to a service that already has one.');
+    if (typeof sandbox !== 'undefined') {
+        Hoek.assert(typeof obj[exports.sandbox] === 'undefined', 'Cannot apply a sandbox setting to a service that already has one.');
         obj[exports.sandbox] = sandbox;
     }
 
@@ -162,8 +162,8 @@ internals.services = (getRealm) => {
 
         if (typeof all === 'string') {
             const namespace = internals.rootState(realm).namespaces[all];
-            Hoek.assert(namespace.size !== 0, `The namespace ${namespace} does not exist.`);
-            Hoek.assert(namespace.size <= 1, `The namespace ${namespace} is not unique.`);
+            Hoek.assert(namespace.size !== 0, `The plugin namespace ${namespace} does not exist.`);
+            Hoek.assert(namespace.size <= 1, `The plugin namespace ${namespace} is not unique.`);
             const [namespaceRealm] = [...namespace.values()];
             return internals.rootState(namespaceRealm).services;
         }
@@ -200,9 +200,7 @@ internals.registerService = function (services) {
 internals.addServiceToRealm = (realm, service, name) => {
 
     const state = internals.state(realm);
-
     Hoek.assert(!state.services[name], `A service named ${name} has already been registered in plugin namespace ${realm.plugin}.`);
-
     state.services[name] = service;
 };
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@hapi/hapi-19": "npm:@hapi/hapi@19",
     "@hapi/lab": "20.x.x",
     "@hapi/somever": "2.x.x",
+    "ahem": "1.x.x",
     "coveralls": "3.x.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,15 +2,21 @@
 
 const Code = require('@hapi/code');
 const Somever = require('@hapi/somever');
+const Ahem = require('ahem');
+const InternalHapi = require('@hapi/hapi');
 const Schmervice = require('..');
 const Lab = require('@hapi/lab');
 
 const Hapi = Somever.match(process.version, '>=12') ? require('@hapi/hapi-19') : require('@hapi/hapi');
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before, after } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 describe('Schmervice', () => {
+
+    before(() => Ahem._setHapi(Hapi));
+
+    after(() => Ahem._setHapi(InternalHapi));
 
     describe('Service class', () => {
 
@@ -482,6 +488,13 @@ describe('Schmervice', () => {
 
     describe('plugin', () => {
 
+        const getPlugin = async (server, name) => {
+
+            const register = () => null;
+
+            return await Ahem.instance(server, { name, register }, {}, { controlled: false });
+        };
+
         it('can be registered multiple times.', async () => {
 
             const server = Hapi.server();
@@ -610,23 +623,19 @@ describe('Schmervice', () => {
                 expect(serviceZ).to.shallow.equal(serviceZObject);
             });
 
-            it('registers hapi plugin instances, respecting their name.', { plan: 2 }, async () => {
+            it('registers hapi plugin instances, respecting their name.', async () => {
 
                 const server = Hapi.server();
                 await server.register(Schmervice);
 
-                await server.register({
-                    name: 'some plugin',
-                    register(srv) {
+                const somePlugin = await getPlugin(server, 'some plugin');
 
-                        server.registerService(srv);
+                server.registerService(somePlugin);
 
-                        const services = server.services();
+                const services = server.services();
 
-                        expect(services).to.only.contain(['somePlugin']);
-                        expect(services.somePlugin).shallow.equal(srv);
-                    }
-                });
+                expect(services).to.only.contain(['somePlugin']);
+                expect(services.somePlugin).shallow.equal(somePlugin);
             });
 
             it('names services in camel-case by default.', async () => {
@@ -681,6 +690,48 @@ describe('Schmervice', () => {
                 expect(services).to.only.contain(['raw-name_class', 'raw-name_function', 'raw-name_object']);
             });
 
+            it('sandboxes services in the current plugin when using Schmervice.sandbox symbol.', async () => {
+
+                const server = Hapi.server();
+                await server.register(Schmervice);
+
+                const ServerService = class ServerService {};
+                server.registerService(class ServiceA extends ServerService {});
+
+                const plugin = await getPlugin(server, 'plugin');
+
+                const PluginService = class PluginService {};
+                plugin.registerService(class ServiceA extends PluginService {
+                    static get [Schmervice.sandbox]() {
+
+                        return true;
+                    }
+                });
+
+                plugin.registerService({
+                    name: 'serviceB',
+                    [Schmervice.sandbox]: 'plugin'
+                });
+
+                plugin.registerService(() => ({
+                    name: 'serviceC',
+                    [Schmervice.sandbox]: true
+                }));
+
+                plugin.registerService({
+                    name: 'serviceD',
+                    [Schmervice.sandbox]: false
+                });
+
+                plugin.registerService(() => ({
+                    name: 'serviceE',
+                    [Schmervice.sandbox]: 'server'
+                }));
+
+                expect(server.services()).to.only.contain(['serviceA', 'serviceD', 'serviceE']);
+                expect(plugin.services()).to.only.contain(['serviceA', 'serviceB', 'serviceC', 'serviceD', 'serviceE']);
+            });
+
             it('throws when passed non-services/factories.', async () => {
 
                 const server = Hapi.server();
@@ -702,13 +753,57 @@ describe('Schmervice', () => {
                 expect(() => server.registerService({})).to.throw('The service must have a name.');
             });
 
-            it('throws when two services with the same name are registered.', async () => {
+            it('throws when two non-sandboxed services with the same name are registered.', async () => {
 
                 const server = Hapi.server();
                 await server.register(Schmervice);
 
                 server.registerService(class ServiceX {});
                 expect(() => server.registerService(class ServiceX {})).to.throw('A service named ServiceX has already been registered.');
+            });
+
+            it('throws when two sandboxed services with the same name are registered in the same namespace.', async () => {
+
+                const server = Hapi.server();
+                await server.register(Schmervice);
+
+                const myPlugin = await getPlugin(server, 'my-plugin');
+
+                myPlugin.registerService({
+                    [Schmervice.name]: 'serviceX',
+                    [Schmervice.sandbox]: true
+                });
+
+                expect(() => {
+
+                    myPlugin.registerService({
+                        [Schmervice.name]: 'serviceX',
+                        [Schmervice.sandbox]: true
+                    });
+                }).to.throw('A service named serviceX has already been registered in plugin namespace my-plugin.');
+            });
+
+            it('throws when a non-sanboxed service shadows a sandboxed service of the same name.', async () => {
+
+                const server = Hapi.server();
+                await server.register(Schmervice);
+
+                const myPlugin = await getPlugin(server, 'my-plugin');
+
+                myPlugin.registerService({
+                    [Schmervice.name]: 'serviceX',
+                    [Schmervice.sandbox]: true
+                });
+
+                const myOtherPlugin = await getPlugin(myPlugin, 'my-other-plugin');
+
+                expect(() => {
+
+                    myOtherPlugin.registerService({
+                        [Schmervice.name]: 'serviceX',
+                        [Schmervice.sandbox]: false
+                    });
+                }).to.throw('A service named serviceX has already been registered in plugin namespace my-plugin.');
             });
         });
 
@@ -760,7 +855,57 @@ describe('Schmervice', () => {
                 });
             });
 
-            it('does not apply a service name to object or class that already has one', async () => {
+            it('optionally applies sandboxing to a service or factory.', async () => {
+
+                // Object
+
+                const obj = { name: 'Unused', some: 'prop' };
+
+                expect(Schmervice.withName('someServiceObject', { sandbox: true }, obj)).to.shallow.equal(obj);
+                expect(obj).to.equal({
+                    [Schmervice.name]: 'someServiceObject',
+                    [Schmervice.sandbox]: true,
+                    name: 'Unused',
+                    some: 'prop'
+                });
+
+                // Class
+
+                const Service = class Service {};
+
+                expect(Schmervice.withName('someServiceClass', { sandbox: false }, Service)).to.shallow.equal(Service);
+                expect(Service[Schmervice.name]).to.equal('someServiceClass');
+                expect(Service[Schmervice.sandbox]).to.equal(false);
+
+                // Sync factory
+
+                const factory = (...args) => ({ name: 'Unused', args });
+
+                expect(Schmervice.withName('someServiceFunction', { sandbox: 'plugin' }, factory)(1, 2, 3)).to.equal({
+                    [Schmervice.name]: 'someServiceFunction',
+                    [Schmervice.sandbox]: 'plugin',
+                    name: 'Unused',
+                    args: [1, 2, 3]
+                });
+
+                // Async factory (not supported by server.registerService(), but useful with haute-couture unwrapping)
+
+                const asyncFactory = async (...args) => {
+
+                    await new Promise((resolve) => setTimeout(resolve, 1));
+
+                    return { name: 'Unused', args };
+                };
+
+                expect(await Schmervice.withName('someServiceAsyncFunction', { sandbox: 'server' }, asyncFactory)(1, 2, 3)).to.equal({
+                    [Schmervice.name]: 'someServiceAsyncFunction',
+                    [Schmervice.sandbox]: 'server',
+                    name: 'Unused',
+                    args: [1, 2, 3]
+                });
+            });
+
+            it('does not apply a service name to object or class that already has one.', async () => {
 
                 // Object
 
@@ -799,6 +944,47 @@ describe('Schmervice', () => {
 
                 await expect(Schmervice.withName('someServiceAsyncFunction', asyncFactory)())
                     .to.reject('Cannot apply a name to a service that already has one.');
+            });
+
+            it('does not apply sandboxing to object or class that already has it set.', async () => {
+
+                // Object
+
+                const obj = { [Schmervice.sandbox]: true };
+
+                expect(() => Schmervice.withName('someServiceObject', { sandbox: false }, obj))
+                    .to.throw('Cannot apply a sandbox setting to a service that already has one.');
+
+                // Class
+
+                const Service = class {
+                    static get [Schmervice.sandbox]() {
+
+                        return false;
+                    }
+                };
+
+                expect(() => Schmervice.withName('someServiceClass', { sandbox: true }, Service))
+                    .to.throw('Cannot apply a sandbox setting to a service that already has one.');
+
+                // Sync factory
+
+                const factory = () => ({ [Schmervice.sandbox]: 'plugin' });
+
+                expect(Schmervice.withName('someServiceFunction', { sandbox: 'plugin' }, factory))
+                    .to.throw('Cannot apply a sandbox setting to a service that already has one.');
+
+                // Async factory (not supported by server.registerService(), but useful with haute-couture unwrapping)
+
+                const asyncFactory = async () => {
+
+                    await new Promise((resolve) => setTimeout(resolve, 1));
+
+                    return { [Schmervice.sandbox]: 'server' };
+                };
+
+                await expect(Schmervice.withName('someServiceAsyncFunction', { sandbox: 'plugin' }, asyncFactory)())
+                    .to.reject('Cannot apply a sandbox setting to a service that already has one.');
             });
         });
 


### PR DESCRIPTION
Included here is the implementation, tests, and docs for namespaces and sandboxing.

Namespaces are an extension to the ability to pass `true` to `server.services(true)` in order to access all services (from the perspective of the root server).  Now you may also pass a plugin name as a string `server.services('my-plugin')` in order to access services from the perspective of that plugin.  In other words, calling `server.services()` inside `my-plugin` is the same as calling `server.services('my-plugin')` from _any_ plugin; identically calling `server.services()` on the root server is the same as calling `server.services(true)` from any plugin.

Sandboxing is a mechanism to opt-out of services being available to all ancestor plugins/namespaces of the plugin that registered the service.  This essentially is the schmervice-y way of having services that are "private" within the plugin that registered them.

These features work together to enable better plugin encapsulation and greater testability, with the ability to not only access, but also mock-out services on a per-plugin basis.