### PR TITLE
Support hapi v21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 import:
-  - source: hapipal/ci-config-travis:node_js.yml@master
-  - source: hapipal/ci-config-travis:hapi_all.yml@master
+  - source: hapipal/ci-config-travis:node_js.yml@hapi-v21
+  - source: hapipal/ci-config-travis:hapi_all.yml@hapi-v21

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2020 Devin Ivy and project contributors
+Copyright (c) 2017-2022 Devin Ivy and project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -31,16 +31,16 @@
   },
   "homepage": "https://github.com/hapipal/schmervice#readme",
   "peerDependencies": {
-    "@hapi/hapi": ">=19 <21"
+    "@hapi/hapi": ">=19 <22"
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x"
+    "@hapi/hoek": "^9.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x",
-    "@hapipal/ahem": "2.x.x",
-    "coveralls": "3.x.x"
+    "@hapi/code": "^8.0.0",
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/lab": "^24.0.0",
+    "@hapipal/ahem": "^2.1.0",
+    "coveralls": "^3.0.0"
   }
 }


### PR DESCRIPTION
Add hapi v21 as a peer and ensure tests pass against hapi v21.

Closes #20 